### PR TITLE
Sign URLs using `signatureKey` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ Probably not needed, but you never know.
 _Make sure you add all the buckets you've set up Craft to use, when you set up your
 Image Handler in AWS._
  
+### signatureKey [string]
+Default: `''`  
+The AWS Image Handler supports using [signed URLs](https://docs.aws.amazon.com/solutions/latest/serverless-image-handler/considerations.html#image-url-signature) 
+to prevent third parties from generating their own transforms. Once you’ve configured the image handler to use them,
+add your signing key and generated URLs will include a `?signature=` param that’s properly hashed and ready to go.
 
+Be careful with this! Once enabled on the server side, any transform URL without a valid signature will return an error.
 
 Price, license and support
 ---

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -9,4 +9,9 @@ class Settings extends Model
     public string $distributionUrl = '';
     public string $defaultBucket = '';
     public bool $autoConvertGif = true;
+
+    /**
+     * @var string Optional secret to be used for signing transform URLs
+     */
+    public string $signatureKey = '';
 }

--- a/src/transformers/AwsServerless.php
+++ b/src/transformers/AwsServerless.php
@@ -195,7 +195,16 @@ class AwsServerless extends Component implements TransformerInterface
             Craft::error($e->getMessage());
             throw new ImagerException($e->getMessage());
         }
-        $url = rtrim($settings->distributionUrl, '/') . '/' . base64_encode($encodedRequestParams);
+
+        $path = '/' . base64_encode($encodedRequestParams);
+        $url = rtrim($settings->distributionUrl, '/') . $path;
+
+        if (! empty($settings->signatureKey)) {
+            // Prepare the signature if the settings model has a key we should use
+            $signature = hash_hmac('sha256', $path, $settings->signatureKey);
+            // Append the signature to the URL
+            $url .= '?signature=' . $signature;
+        }
         
         return new AwsServerlessTransformedImageModel($url, $image, $requestParams);
     }


### PR DESCRIPTION
This adds and documents support for a `signatureKey` setting that can be used to generate signed URLs, resolving #6.

Tested locally of course, and nothing explodes.