### PR TITLE
Add dateUpdated param to assist with cache busting

### DIFF
--- a/src/transformers/AwsServerless.php
+++ b/src/transformers/AwsServerless.php
@@ -91,6 +91,11 @@ class AwsServerless extends Component implements TransformerInterface
 
         $requestParams['key'] = AwsServerlessHelpers::getImageKey($image);
 
+        // Add dateUpdated timestamp to cache-bust transformed URLs when the asset changes
+        if ($image->dateUpdated) {
+            $requestParams['dateUpdated'] = $image->dateUpdated->getTimestamp();
+        }
+
         $edits = [
             'resize' => $transformerParams['resize'] ?? []
         ];


### PR DESCRIPTION
We have recently started using the AWS Serverless transformer with Imager X and it's been working really great!

We discovered an issue today with image edits (focal point, crop, etc.) not cache busting CloudFront. These edits occur to the original image and the filename (key) remains the same. This means that the base64 encoded string is also the same and does not automatically cache bust the CloudFront distribution. The original image is being cache busted by Craft's own support for CloudFront invalidations but any transforms are not. If the base64 encoded string is tweaked, then it works and I can see my changes.

To workaround this, I am including the original image's dateUpdated timestamp in the parameters sent to Lambda. This is working great for me. I can make any updates to the image and then I can see the transform being regenerated immediately. The Lambda functon doesn't care about this extra data and simply ignores it.

I feel this could work well for others so contributing it here. Let me know if you have any thoughts, questions or concerns.